### PR TITLE
feat: Add pagination feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Feel free to modify or extend the bot's commands to suit your needs. You can fin
 ## Features
 
 - [x] Help page `help`
-- [ ] Pagination
+- [x] Pagination
 - [x] Show information about the guild `server`
 - [x] Show information about the user `user`
 - Audio

--- a/src/commands/utility/help.ts
+++ b/src/commands/utility/help.ts
@@ -1,23 +1,44 @@
-require('dotenv').config();
-import { ChatInputCommandInteraction, Message, SlashCommandBuilder } from 'discord.js';
-import { Command } from '../../definitions.js';
+import 'dotenv/config';
+import {
+	ChatInputCommandInteraction,
+	EmbedBuilder,
+	Message,
+	SlashCommandBuilder
+} from 'discord.js';
+import { Command } from '../../definitions';
+import { pagination } from '../../functions';
 
 const PREFIX = process.env.PREFIX;
 
 module.exports = <Command> {
-      data: new SlashCommandBuilder().setName('help').setDescription('Bot Help page'),
-      execute: async (message: Message | ChatInputCommandInteraction) => {
-            // TODO: add help page for single command
-            await message.reply(
-                  message.client.commands
-                        .sort((commandA: Command, commandB: Command) =>
-                              commandA.data.name > commandB.data.name ? 1 : -1,
-                        )
-                        .map(
-                              (command: Command, key: string) =>
-                                    `${PREFIX}${key}: ${command.data.description}`,
-                        )
-                        .join('\n'),
-            );
-      },
+	data: new SlashCommandBuilder().setName('help').setDescription('Bot Help page'),
+	execute: async (message: Message | ChatInputCommandInteraction) => {
+		// TODO: add help page for single command
+		// TODO: Add menu selection, spread commands over categories
+		// TODO: Add options
+
+		const embedCommands: EmbedBuilder[] = Array
+			.from(message.client.commands.values())
+			.sort((commandA: Command, commandB: Command) => {
+				return commandA.data.name > commandB.data.name ? 1 : -1;
+			})
+			.map((command, i, array) => {
+				return new EmbedBuilder()
+					.setTitle('Help Page')
+					.setDescription(`/${command.data.name}`)
+					.setColor(0x00FF00)
+					.setTimestamp()
+					.setFooter({
+						text: `Page ${i + 1} / ${array.length}`
+					})
+					.addFields(
+						{
+							name: `${PREFIX}${command.data.name}`,
+							value: command.data.description,
+						}
+					);
+			});
+
+		pagination(message, embedCommands);
+	},
 };

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,0 +1,96 @@
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	ChatInputCommandInteraction,
+	ComponentType,
+	EmbedBuilder,
+	Message
+} from 'discord.js';
+
+enum PageButtonID {
+	Home     = 'home',
+	Next     = 'next',
+	Previous = 'previous',
+}
+
+const pageButtonLabel = function (id: PageButtonID): string {
+	switch (id) {
+	case PageButtonID.Home:
+		return 'Home';
+	case PageButtonID.Next:
+		return 'Next Page';
+	case PageButtonID.Previous:
+		return 'Previous Page';
+	}
+};
+
+export const pagination = async function(
+	message: Message | ChatInputCommandInteraction,
+	pages: EmbedBuilder[],
+	pageIndex: number = 0
+) {
+	if (pages.length === 0) {
+		console.error('Empty pages');
+		return;
+	}
+		
+	const defaultPageIndex: number = pageIndex;
+	const paginationButtonRow = new ActionRowBuilder<ButtonBuilder>()
+		.addComponents(
+			new ButtonBuilder()
+				.setCustomId(PageButtonID.Previous)
+				.setLabel(pageButtonLabel(PageButtonID.Previous))
+				.setStyle(ButtonStyle.Secondary)
+				.setEmoji('⬅️'),
+			new ButtonBuilder()
+				.setCustomId(PageButtonID.Home)
+				.setLabel(pageButtonLabel(PageButtonID.Home))
+				.setStyle(ButtonStyle.Primary)
+				.setEmoji('🏠'),
+			new ButtonBuilder()
+				.setCustomId(PageButtonID.Next)
+				.setLabel(pageButtonLabel(PageButtonID.Next))
+				.setStyle(ButtonStyle.Success)
+				.setEmoji('➡️'),
+		);
+
+	const response = await message.reply({
+		embeds: [pages[defaultPageIndex]],
+		components: [paginationButtonRow],
+	});
+
+	const editResponse = async () => await response.edit({
+		embeds: [pages[pageIndex]],
+		components: [paginationButtonRow],
+	});
+
+	const collector = response.createMessageComponentCollector({
+		componentType: ComponentType.Button,
+		// TODO: Magic Number
+		time: 5 * 60 * 1e3,
+		filter: interaction => {
+			interaction.deferUpdate();
+			return interaction.user.id === message.member.user.id;
+		},
+	});
+
+	collector.on('collect', async interaction => {
+		collector.resetTimer();
+
+		if (interaction.customId === PageButtonID.Home)
+			pageIndex = defaultPageIndex;
+		else if (interaction.customId === PageButtonID.Previous)
+			pageIndex = (pages.length + pageIndex - 1) % pages.length;
+		else if (interaction.customId === PageButtonID.Next)
+			pageIndex = (pageIndex + 1) % pages.length;
+
+		editResponse();
+	});
+
+	collector.on('end', () => {
+		paginationButtonRow.components.forEach(button => button.setDisabled(true));
+
+		editResponse();
+	});
+};


### PR DESCRIPTION
- Updated the `help.ts` file in the `src/commands/utility` directory to implement pagination for the bot's help page.
- Added a new function `pagination` in the `src/functions.ts` file to handle the pagination logic.
- The `pagination` function takes an array of `EmbedBuilder` objects representing the pages, and displays the initial page along with navigation buttons.
- Users can navigate between pages using the "Previous Page" and "Next Page" buttons.
- The function also includes a "Home" button that takes the user back the first page.
- The function uses Discord.js components and message collectors to handle user interactions and update the displayed page accordingly.

Note: There are still some TODOs in the code for future improvements.